### PR TITLE
Add "Apps for Websites" support

### DIFF
--- a/public/windows-app-web-link
+++ b/public/windows-app-web-link
@@ -1,0 +1,12 @@
+[
+    {
+        "packageFamilyName": "52374YoshiAskharoun.UWPCommunity_bcem08bwhrc72",
+        "paths": [
+            "*"
+        ],
+        "excludePaths": [
+            "/news/*",
+            "/blog/*"
+        ]
+    }
+]


### PR DESCRIPTION
This file adds "Apps for Websites". This means that whenever a user goes to the UWP Community website, MS Edge will attempt to open that URL in the listed app (in this case, the UWP Community companion app). I do not think this works in other browsers, but I have no way to confirm this myself.